### PR TITLE
Improve breakpoints

### DIFF
--- a/src/client/components/Profile.js
+++ b/src/client/components/Profile.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Viewport } from '@aragon/ui'
+import { BREAKPOINTS, breakpoint } from '@aragon/ui'
 
 import InformationPanel from './informationPanel'
 // import OrganizationPanel from './OrganizationPanel'
@@ -9,66 +9,37 @@ import WorkHistoryPanel from './WorkHistoryPanel'
 import CoverImage from './CoverImage'
 
 const Profile = () => (
-  <div css="width: 100%">
+  <React.Fragment>
     <CoverImage />
-    <Viewport>
-      {({ below }) =>
-        below(640) ? (
-          <SingleColumn>
-            <InformationPanel />
-            {/*
-            <OrganizationPanel />
-            */}
-            <WorkHistoryPanel />
-            <EducationPanel />
-          </SingleColumn>
-        ) : (
-          <DoubleColumn>
-            <LeftColumn>
-              <InformationPanel />
-              <EducationPanel />
-            </LeftColumn>
-            <RightColumn>
-              {/*
-                For future reference: this will be re-enabled
-                when it is possible to confirm membership in external DAOs.
+    <Grid>
+      <InformationPanel />
+      {/*
+        For future reference: this will be re-enabled
+        when it is possible to confirm membership in external DAOs.
 
-                What is left in place: modal allowing to add membership record,
-                events and all state-related code, incomplete styling for DAOs
-                Membership Panel.
-              <OrganizationPanel />
-              */}
-              <WorkHistoryPanel />
-            </RightColumn>
-          </DoubleColumn>
-        )
-      }
-    </Viewport>
-  </div>
+        What is left in place: modal allowing to add membership record,
+        events and all state-related code, incomplete styling for DAOs
+        Membership Panel.
+      <OrganizationPanel />
+      */}
+      <WorkHistoryPanel css="grid-row: span 2" />
+      <EducationPanel />
+    </Grid>
+  </React.Fragment>
 )
 
-const LeftColumn = styled.div`
-  display: flex;
-  flex-direction: column;
+const Grid = styled.div`
+  display: grid;
+  grid-gap: 26px;
+  margin: 0 auto;
+  max-width: ${BREAKPOINTS.large}px;
+  padding: 30px;
   width: 100%;
-  max-width: 400px;
-  margin: 13px;
-  > * {
-    margin-bottom: 26px;
-  }
-`
-const RightColumn = styled(LeftColumn)`
-  width: 100%;
-  max-width: 600px;
-`
-const SingleColumn = styled(RightColumn)`
-  width: auto;
-  align-content: stretch;
-`
-const DoubleColumn = styled.div`
-  display: flex;
-  flex-direction: row;
-  padding: 0 26px;
+  ${breakpoint(
+    'small',
+    'grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));'
+  )};
+  ${breakpoint('large', 'grid-template-columns: 2fr 3fr')};
 `
 
 export default Profile

--- a/src/client/components/WorkHistoryPanel.js
+++ b/src/client/components/WorkHistoryPanel.js
@@ -8,7 +8,7 @@ import { Text } from '@aragon/ui'
 import styled from 'styled-components'
 import { Link } from './styled-components'
 
-const WorkHistoryPanel = () => {
+const WorkHistoryPanel = ({ className }) => {
   const { workHistory, viewMode } = useProfile()
   const { dispatchModal } = useContext(ModalContext)
 
@@ -18,6 +18,7 @@ const WorkHistoryPanel = () => {
     title: 'Work history',
     addMore: historyNotEmpty ? () => dispatchModal(open('workHistory')) : null,
     addSeparators: true,
+    className,
     viewMode,
   }
 

--- a/src/client/components/informationPanel/ProfilePicture.js
+++ b/src/client/components/informationPanel/ProfilePicture.js
@@ -49,8 +49,8 @@ const Container = styled.div`
   width: 150px;
   height: 150px;
   position: absolute;
-  top: 52px;
-  left: 52px;
+  bottom: calc(100% - 30px);
+  left: 30px;
   z-index: 4;
   ${props =>
     props.imageCid

--- a/src/client/components/informationPanel/index.js
+++ b/src/client/components/informationPanel/index.js
@@ -18,6 +18,7 @@ const AlignCenter = styled.div`
   flex-direction: column;
   align-items: center;
   margin-top: -9px;
+  position: relative;
 `
 
 export default LeftPanel

--- a/src/client/wrappers/styleWrappers/CardWrapper.js
+++ b/src/client/wrappers/styleWrappers/CardWrapper.js
@@ -4,8 +4,15 @@ import { Card, Text } from '@aragon/ui'
 import styled from 'styled-components'
 import { Link } from '../../components/styled-components'
 
-const CardWrapper = ({ children, title, addMore, addSeparators, viewMode }) => (
-  <div css="width: 100%">
+const CardWrapper = ({
+  children,
+  className,
+  title,
+  addMore,
+  addSeparators,
+  viewMode,
+}) => (
+  <div css="width: 100%" className={className}>
     {title && (
       <Text css="padding: 7px 0" size="xlarge">
         {title}
@@ -30,6 +37,7 @@ CardWrapper.defaultProps = {
 
 CardWrapper.propTypes = {
   children: PropTypes.node,
+  className: PropTypes.string,
   title: PropTypes.string,
   addMore: PropTypes.func,
   addSeparators: PropTypes.bool,


### PR DESCRIPTION
Fixes #38 

This uses a combination of media queries and `minmax` to have three main breakpoints:

* no grid-template-columns set - cards take up full width
* grid-template-columns with minmax(350px, 1fr) - columns are at least 350px wide, equal width
* grid-template-columns: 2fr 3fr - two columns, first takes up 2/5th of the space and the second 3/5th

![profile responsive behavior](https://user-images.githubusercontent.com/221614/61407522-ef596d00-a8ab-11e9-9a94-520408f328db.gif)
---
![profile responsive behavior, view 2](https://user-images.githubusercontent.com/221614/61407932-e0bf8580-a8ac-11e9-982b-55f105f9601e.gif)
