### PR TITLE
bugfix/DateDropdowns: allow selecting dates

### DIFF
--- a/src/client/components/DateDropdowns.js
+++ b/src/client/components/DateDropdowns.js
@@ -5,6 +5,13 @@ import { Checkbox, Field } from '@aragon/ui'
 import { DropDownWithValidation } from './styled-components'
 import { years, months } from '../utils'
 
+// copied from aragonUI Field
+const Label = styled.label`
+  text-transform: lowercase;
+  font-variant: small-caps;
+  color: #707070;
+`
+
 const DateDropdowns = ({
   current,
   dispatchDateChange,
@@ -43,47 +50,44 @@ const DateDropdowns = ({
       </DateDropDowns>
     </Field>
 
-    <Field label="End Date">
-      <div css="display: flex; height: 40px;">
-        {!current && (
-          <DateDropDowns>
-            <div css="width: 48%;">
-              <DropDownWithValidation
-                wide
-                items={months}
-                active={indexEndMonth}
-                onChange={index =>
-                  dispatchDateChange({ type: 'setIndexEndMonth', index })
-                }
-                error={error}
-              />
-            </div>
-            <div css="width: 48%;">
-              <DropDownWithValidation
-                wide
-                items={years}
-                active={indexEndYear}
-                onChange={index =>
-                  dispatchDateChange({ type: 'setIndexEndYear', index })
-                }
-                error={error}
-              />
-            </div>
-          </DateDropDowns>
-        )}
-        <div css="display: flex; align-items: center;">
-          <Checkbox
-            checked={current}
-            onChange={index =>
-              dispatchDateChange({ type: 'setCurrent', index })
-            }
-          />
-          {type === 'workHistory'
-            ? 'I currently work here'
-            : 'I currently study here'}
-        </div>
-      </div>
-    </Field>
+    <Label>End Date</Label>
+    <div css="display: flex; height: 40px; margin-bottom: 20px;">
+      {!current && (
+        <DateDropDowns>
+          <div css="width: 48%;">
+            <DropDownWithValidation
+              wide
+              items={months}
+              active={indexEndMonth}
+              onChange={index =>
+                dispatchDateChange({ type: 'setIndexEndMonth', index })
+              }
+              error={error}
+            />
+          </div>
+          <div css="width: 48%;">
+            <DropDownWithValidation
+              wide
+              items={years}
+              active={indexEndYear}
+              onChange={index =>
+                dispatchDateChange({ type: 'setIndexEndYear', index })
+              }
+              error={error}
+            />
+          </div>
+        </DateDropDowns>
+      )}
+      <label css="display: flex; align-items: center;">
+        <Checkbox
+          checked={current}
+          onChange={index => dispatchDateChange({ type: 'setCurrent', index })}
+        />
+        {type === 'workHistory'
+          ? 'I currently work here'
+          : 'I currently study here'}
+      </label>
+    </div>
   </Fragment>
 )
 

--- a/src/client/components/DateDropdowns.js
+++ b/src/client/components/DateDropdowns.js
@@ -18,11 +18,7 @@ const DateDropdowns = ({
   <Fragment>
     <Field label="Start Date">
       <DateDropDowns>
-        <div
-          css={`
-            width: 48%;
-          `}
-        >
+        <div css="width: 48%;">
           <DropDownWithValidation
             wide
             items={months}
@@ -33,11 +29,7 @@ const DateDropdowns = ({
             error={error}
           />
         </div>
-        <div
-          css={`
-            width: 48%;
-          `}
-        >
+        <div css="width: 48%;">
           <DropDownWithValidation
             wide
             items={years}
@@ -52,19 +44,10 @@ const DateDropdowns = ({
     </Field>
 
     <Field label="End Date">
-      <div
-        css={`
-          display: flex;
-          height: 40px;
-        `}
-      >
+      <div css="display: flex; height: 40px;">
         {!current && (
           <DateDropDowns>
-            <div
-              css={`
-                width: 48%;
-              `}
-            >
+            <div css="width: 48%;">
               <DropDownWithValidation
                 wide
                 items={months}
@@ -75,11 +58,7 @@ const DateDropdowns = ({
                 error={error}
               />
             </div>
-            <div
-              css={`
-                width: 48%;
-              `}
-            >
+            <div css="width: 48%;">
               <DropDownWithValidation
                 wide
                 items={years}
@@ -92,12 +71,7 @@ const DateDropdowns = ({
             </div>
           </DateDropDowns>
         )}
-        <div
-          css={`
-            display: flex;
-            align-items: center;
-          `}
-        >
+        <div css="display: flex; align-items: center;">
           <Checkbox
             checked={current}
             onChange={index =>


### PR DESCRIPTION
Previously, clicking on a date dropdown checked the `current` box, which
hid the input. This is because the checkbox was nested within the Field,
which uses a label element to link the label and the inputs.