### PR TITLE
Scale and center cover image

### DIFF
--- a/src/client/components/CoverImage.js
+++ b/src/client/components/CoverImage.js
@@ -44,6 +44,8 @@ const CoverBase = styled.div`
   width: 100%;
   height: 156px;
   position: relative;
+  background-size: cover;
+  background-position: center;
 `
 const CoverPicture = styled(CoverBase)`
   background-image: ${props => getBackground(props)};


### PR DESCRIPTION
Make the banner image prettier by always showing its full width/height (whichever is smaller) and centering it.

## Before

<img width="763" alt="Screen Shot 2019-07-24 at 16 29 25" src="https://user-images.githubusercontent.com/221614/61826429-65238280-ae30-11e9-8656-c08c0d595b49.png">

## After

<img width="769" alt="Screen Shot 2019-07-24 at 16 30 31" src="https://user-images.githubusercontent.com/221614/61826430-65bc1900-ae30-11e9-9699-2528dbb82f43.png">