### PR TITLE
Fix height calculation for work history column

### DIFF
--- a/src/client/components/Profile.js
+++ b/src/client/components/Profile.js
@@ -23,7 +23,7 @@ const Profile = () => (
         Membership Panel.
       <OrganizationPanel />
       */}
-      <WorkHistoryPanel css="grid-row: span 2" />
+      <WorkHistoryPanel css="grid-row: span 20" />
       <EducationPanel />
     </Grid>
   </React.Fragment>


### PR DESCRIPTION
When calculating the number of rows for this grid, the browser uses approximately equally-heighted rows for each (why?). This is somehow related to the `grid-row: span 2` setting on this right-side column.

Using a larger span setting (in this case 20) means that each of the first two _real_ rows can match the height of the content on the left, and the excessive height of the right-side column spills into the superfluous rows.

I find this solution deeply unsatisfying, and wish I could answer that "why" question above instead.

## Before

<img width="826" alt="before" src="https://user-images.githubusercontent.com/221614/61841156-d16aaa00-ae61-11e9-8ea9-52a1e68d13fa.png">

## After

<img width="839" alt="after" src="https://user-images.githubusercontent.com/221614/61841155-d16aaa00-ae61-11e9-8bbc-c0667be27ab4.png">
