### PR TITLE
Other's profiles: Don't show "verify account"

### DIFF
--- a/src/client/components/informationPanel/InformationCard.js
+++ b/src/client/components/informationPanel/InformationCard.js
@@ -47,17 +47,21 @@ const InformationCard = () => {
             </Fragment>
           )}
           <Website website={website} />
-          <Separator />
-          <Twitter
-            twitter={twitter}
-            activePopover={activePopover}
-            setPopover={setPopover}
-          />
-          <GitHub
-            github={github}
-            activePopover={activePopover}
-            setPopover={setPopover}
-          />
+          {(!viewMode || twitter.username || github.username) && <Separator />}
+          {(!viewMode || twitter.username) && (
+            <Twitter
+              twitter={twitter}
+              activePopover={activePopover}
+              setPopover={setPopover}
+            />
+          )}
+          {(!viewMode || github.username) && (
+            <GitHub
+              github={github}
+              activePopover={activePopover}
+              setPopover={setPopover}
+            />
+          )}
           <Separator />
           <Social>
             <IconEthereum width="13px" height="13px" />


### PR DESCRIPTION
When you're viewing someone else's account, it shouldn't say "verify
your twitter" or "verify your github"! This fixes it. It also only puts
in one separator, if neither account is set.

Now it looks like this, when viewing someone else's account:
<img width="362" alt="Screen Shot 2019-07-25 at 10 29 05" src="https://user-images.githubusercontent.com/221614/61882797-2f7da880-aec7-11e9-8ef5-a994997c8621.png">
