### PR TITLE
Improve hint about starting URL with https

### DIFF
--- a/src/client/components/modals/BasicInformation.js
+++ b/src/client/components/modals/BasicInformation.js
@@ -67,7 +67,7 @@ const BasicInformation = ({
             wide
             value={getFormValue('website')}
             onChange={e => onChange(e.target.value, 'website')}
-            placeholder="https://"
+            placeholder="Enter a website starting with https://"
             type="url"
             error={validationErrors['website']}
           />


### PR DESCRIPTION
Long-term, we want to move away from using placeholder text as a hint,
and allow entering a URL without the explicit protocol at the beginning.
For now, though, this adds some clarity to a potentially confusing UX.