### PR TITLE
Edit Basic Info: Move Location field below Bio

### DIFF
--- a/src/client/components/modals/BasicInformation.js
+++ b/src/client/components/modals/BasicInformation.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Button, Field, TextInput } from '@aragon/ui'
 import PropTypes from 'prop-types'
-import { ModalWrapper, TwoColumnsRow, DisplayErrors } from './ModalWrapper'
+import { ModalWrapper, DisplayErrors } from './ModalWrapper'
 import {
   TextInputWithValidation,
   TextMultilineWithValidation,
@@ -37,23 +37,14 @@ const BasicInformation = ({
     <ModalWrapper title="Edit Basic Information">
       <form onSubmit={validateAndSave}>
         <DisplayErrors errors={{ ...validationErrors, ...savingError }} />
-        <TwoColumnsRow>
-          <Field label="Name">
-            <TextInputWithValidation
-              wide
-              onChange={e => onChange(e.target.value, 'name')}
-              value={getFormValue('name')}
-              error={validationErrors['name']}
-            />
-          </Field>
-          <Field label="Location">
-            <TextInput
-              wide
-              onChange={e => onChange(e.target.value, 'location')}
-              value={getFormValue('location')}
-            />
-          </Field>
-        </TwoColumnsRow>
+        <Field label="Name">
+          <TextInputWithValidation
+            wide
+            onChange={e => onChange(e.target.value, 'name')}
+            value={getFormValue('name')}
+            error={validationErrors['name']}
+          />
+        </Field>
 
         <Field label="Bio">
           <TextMultilineWithValidation
@@ -62,6 +53,15 @@ const BasicInformation = ({
             onChange={e => onChange(e.target.value, 'description')}
           />
         </Field>
+
+        <Field label="Location">
+          <TextInput
+            wide
+            onChange={e => onChange(e.target.value, 'location')}
+            value={getFormValue('location')}
+          />
+        </Field>
+
         <Field label="Website">
           <TextInputWithValidation
             wide


### PR DESCRIPTION
This matches the order of the page better, and makes it seem less like a
"First Name / Last Name" pairing on the first line of the form.

## Before
<img width="613" alt="before" src="https://user-images.githubusercontent.com/221614/61885439-d3695300-aecb-11e9-8142-1dfe50e0adfa.png">

## After

<img width="608" alt="after" src="https://user-images.githubusercontent.com/221614/61885438-d3695300-aecb-11e9-80c6-148f7ff4b01c.png">