### PR TITLE
Hide Work/Edu History when no info & not editing

### DIFF
--- a/src/client/components/EducationPanel.js
+++ b/src/client/components/EducationPanel.js
@@ -13,11 +13,13 @@ const EducationPanel = () => {
   const { educationHistory, viewMode } = useProfile()
   const { dispatchModal } = useContext(ModalContext)
 
-  const historyNotEmpty = Object.keys(educationHistory).length > 0
+  const historyPresent = Object.keys(educationHistory).length > 0
+
+  if (!historyPresent && viewMode) return null
 
   const cardProps = {
     title: 'Education',
-    addMore: historyNotEmpty
+    addMore: historyPresent
       ? () => dispatchModal(open('educationHistory'))
       : null,
     addSeparators: true,
@@ -26,7 +28,7 @@ const EducationPanel = () => {
 
   return (
     <CardWrapper {...cardProps}>
-      {historyNotEmpty ? (
+      {historyPresent ? (
         sortHistory(educationHistory).map(item => (
           <EducationHistoryTile
             key={item.id}
@@ -41,14 +43,12 @@ const EducationPanel = () => {
       ) : (
         <Center>
           <Text size="normal">No education added</Text>
-          {!viewMode && (
-            <Link.Button
-              onClick={() => dispatchModal(open('educationHistory'))}
-              size="small"
-            >
-              Add education
-            </Link.Button>
-          )}
+          <Link.Button
+            onClick={() => dispatchModal(open('educationHistory'))}
+            size="small"
+          >
+            Add education
+          </Link.Button>
         </Center>
       )}
     </CardWrapper>

--- a/src/client/components/WorkHistoryPanel.js
+++ b/src/client/components/WorkHistoryPanel.js
@@ -14,11 +14,13 @@ const WorkHistoryPanel = ({ className }) => {
   const { workHistory, viewMode } = useProfile()
   const { dispatchModal } = useContext(ModalContext)
 
-  const historyNotEmpty = Object.keys(workHistory).length > 0
+  const historyPresent = Object.keys(workHistory).length > 0
+
+  if (!historyPresent && viewMode) return null
 
   const cardProps = {
     title: 'Work history',
-    addMore: historyNotEmpty ? () => dispatchModal(open('workHistory')) : null,
+    addMore: historyPresent ? () => dispatchModal(open('workHistory')) : null,
     addSeparators: true,
     className,
     viewMode,
@@ -26,7 +28,7 @@ const WorkHistoryPanel = ({ className }) => {
 
   return (
     <CardWrapper {...cardProps}>
-      {historyNotEmpty ? (
+      {historyPresent ? (
         sortHistory(workHistory).map(item => (
           <WorkHistoryTile
             key={item.id}
@@ -39,14 +41,12 @@ const WorkHistoryPanel = ({ className }) => {
       ) : (
         <Center>
           <Text size="normal">No work history added</Text>
-          {!viewMode && (
-            <Link.Button
-              onClick={() => dispatchModal(open('workHistory'))}
-              size="small"
-            >
-              Add work
-            </Link.Button>
-          )}
+          <Link.Button
+            onClick={() => dispatchModal(open('workHistory'))}
+            size="small"
+          >
+            Add work
+          </Link.Button>
         </Center>
       )}
     </CardWrapper>


### PR DESCRIPTION
No reason to show empty boxes if there's no action to take.

Screenshots:

<img width="815" alt="Screen Shot 2019-07-25 at 15 19 35" src="https://user-images.githubusercontent.com/221614/61902321-c0687a00-aeef-11e9-8c3f-692e8b3dac79.png">

---

<img width="818" alt="Screen Shot 2019-07-25 at 15 19 54" src="https://user-images.githubusercontent.com/221614/61902322-c0687a00-aeef-11e9-8d5c-cfcc658af193.png">
