### PR TITLE
Improve row height math

### DIFF
--- a/src/client/components/Profile.js
+++ b/src/client/components/Profile.js
@@ -23,7 +23,7 @@ const Profile = () => (
         Membership Panel.
       <OrganizationPanel />
       */}
-      <WorkHistoryPanel css="grid-row: span 20" />
+      <WorkHistoryPanel css="grid-row: span 2" />
       <EducationPanel />
     </Grid>
   </React.Fragment>
@@ -34,7 +34,10 @@ const Grid = styled(ContentWrap)`
   grid-column-gap: 26px;
   ${breakpoint(
     'small',
-    'grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));'
+    `
+      grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+      grid-template-rows: auto 1fr;
+    `
   )};
   ${breakpoint('large', 'grid-template-columns: 2fr 3fr')};
 `


### PR DESCRIPTION
This improves #83 / 6c41a48. Rather than use a hack on the `grid-row: span X` for the right-side item, this instructs the browser to auto-size the first row to the content, and use the rest of the available space for the second row. This means the first row will be as short as possible.

The screenshots from #83 are still relevant here; this is an internal logic change only, which I believe makes the CSS more understandable.